### PR TITLE
Speed

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,3 +53,7 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
       - name: Options
-        shell: R -q -e "(repos <- getOptions('repos'));contrib.url(repos)"
+        run: R -q -e "(repos <- getOptions('repos'));contrib.url(repos)"
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,7 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
           cran: https://CRAN.R-project.org
+          extra-repositories: https://CRAN.R-project.org
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master, default]
   pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check.yaml
 
@@ -39,6 +40,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          cran: https://CRAN.R-project.org
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
       - name: Options
-        run: R -q -e "(repos <- getOptions('repos'));contrib.url(repos)"
+        run: R -q -e "(repos <- getOption('repos'));contrib.url(repos)"
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,8 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-
+      - name: Options
+        shell: R -q -e "(repos <- getOptions('repos'));contrib.url(repos)"
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           use-public-rspm: true
           r-version: devel
+          cran: https://CRAN.R-project.org
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -5,3 +5,5 @@ pkg_state <- new.env(parent = emptyenv())
 PACKAGE_FIELDS <- c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")
 
 BASE <- tools::standard_package_names()$base
+
+options(repos = "https://CRAN.R-project.org")

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -6,4 +6,4 @@ PACKAGE_FIELDS <- c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")
 
 BASE <- tools::standard_package_names()$base
 
-options(repos = "https://CRAN.R-project.org")
+options(repos = c("@CRAN@" = "https://CRAN.R-project.org"))

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -6,4 +6,12 @@ PACKAGE_FIELDS <- c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")
 
 BASE <- tools::standard_package_names()$base
 
-options(repos = c("@CRAN@" = "https://CRAN.R-project.org"))
+.onAttach <- function(libname, pkgname) {
+    opts <- options(repos = c("@CRAN@" = "https://CRAN.R-project.org"),
+            available_packages_filters = c("CRAN", "duplicates"))
+    pkg_state$opts <- opts
+}
+
+.onDetach <- function(libpath) {
+    options(pkg_state$opts)
+}

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -2,13 +2,24 @@ cran_tz <- "Europe/Vienna"
 
 pkg_state <- new.env(parent = emptyenv())
 
+#' Clean cache
+#' 
+#' Clean cache to download repository data again.
+#' @details
+#' Cleans the package's environment used for caching the data.
+#' @returns NULL
+#' @export
+clean_cache <- function() {
+    pkg_state <- new.env(parent = emptyenv())
+    NULL
+}
+
 PACKAGE_FIELDS <- c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")
 
 BASE <- tools::standard_package_names()$base
 
 .onAttach <- function(libname, pkgname) {
-    opts <- options(repos = c("@CRAN@" = "https://CRAN.R-project.org"),
-            available_packages_filters = c("CRAN", "duplicates"))
+    opts <- options(repos = c("@CRAN@" = "https://CRAN.R-project.org"))
     pkg_state$opts <- opts
 }
 

--- a/R/alias_utils.R
+++ b/R/alias_utils.R
@@ -9,7 +9,7 @@ alias2df <- function(x) {
     })
     aliasesDF <- do.call(rbind, l)
     aliasesDF <- cbind(aliasesDF, Package = rep(names(l), vapply(l, NROW, numeric(1L))))
-    aliasesDF[, c("Package", "Source", "Target")]
+    aliasesDF[, c("Package", "Source", "Target"), drop = FALSE]
 }
 
 

--- a/R/alias_utils.R
+++ b/R/alias_utils.R
@@ -1,12 +1,15 @@
 
-alias2df <- function(x){
+alias2df <- function(x) {
+    if (!length(x)) {
+        return(NULL)
+    }
+
     l <- lapply(x, function(x) {
         cbind(Source = rep(names(x), lengths(x)), Target = funlist(x))
     })
     aliasesDF <- do.call(rbind, l)
     aliasesDF <- cbind(aliasesDF, Package = rep(names(l), vapply(l, NROW, numeric(1L))))
-
-    aliasesDF
+    aliasesDF[, c("Package", "Source", "Target")]
 }
 
 

--- a/R/alias_utils.R
+++ b/R/alias_utils.R
@@ -48,7 +48,7 @@ dup_alias <- function(alias) {
     df <- duplicated(alias[, "Target"])
     dup_targets <- unique(alias[df, "Target"])
     pkg_df <- alias[alias[, "Target"] %in% dup_targets, ]
-    pkg_df <- sort_by(pkg_df, ~Target+Package+Source)
+    pkg_df <- sort_by(pkg_df, pkg_df[, c("Target", "Package", "Source")])
     rownames(pkg_df) <- NULL
     pkg_df
 }

--- a/R/alias_utils.R
+++ b/R/alias_utils.R
@@ -1,4 +1,3 @@
-
 alias2df <- function(x) {
     if (!length(x)) {
         return(NULL)
@@ -12,8 +11,7 @@ alias2df <- function(x) {
     aliasesDF[, c("Package", "Source", "Target"), drop = FALSE]
 }
 
-
-check_alias <- function(alias) {
+warnings_alias <- function(alias) {
 
     if (length(unique(alias[, "Package"])) <= 1L) {
         paths <- grepl("/", alias[, "Source"], fixed = TRUE)
@@ -23,7 +21,7 @@ check_alias <- function(alias) {
     }
 
     s <- split(as.data.frame(alias), alias[, "Package"])
-    more_alias <- vapply(s, check_alias, logical(1L))
+    more_alias <- vapply(s, warnings_alias, logical(1L))
     names(more_alias) <- names(s)
     # Recursive call
     if (sum(more_alias) > 1L) {

--- a/R/arch_utils.R
+++ b/R/arch_utils.R
@@ -51,6 +51,9 @@ arch2m <- function(arch){
 }
 
 arch2df <- function(x) {
+    if (is.null(x)) {
+        return(NULL)
+    }
     x <- as.data.frame(x)
     x$size <- as.numeric(x$size)
     x$mtime <- as.POSIXct(x$mtime, tz = cran_tz)

--- a/R/arch_utils.R
+++ b/R/arch_utils.R
@@ -1,0 +1,76 @@
+str2mat <- function(pattern, x, columns, perl = FALSE, useBytes = FALSE){
+    m <- regexec(pattern, x, perl = perl, useBytes = useBytes)
+    str <- regmatches(x, m)
+    ntokens <- length(columns) + 1L
+    nomatch <- lengths(str) == 0L
+    str[nomatch] <- list(rep.int(NA_character_, ntokens))
+    if (length(str) > 0L && length(str[[1L]]) != ntokens) {
+        stop("The number of captures in 'pattern' != 'length(proto)'")
+    }
+    mat <- matrix(as.character(unlist(str)), ncol = ntokens,
+        byrow = TRUE)[, -1L, drop = FALSE]
+    colnames(mat) <- columns
+    mat
+}
+
+curr2m <- function(pkges) {
+    curr <- as.matrix(pkges[, c("mtime", "size", "uname")])
+    # dse packages has unorthodox version number
+    pkg_v <- str2mat(pattern = "(.+)_(.+)\\.tar\\.gz",
+                     x = rownames(pkges),
+                     columns = c("package", "version"))
+    x <- cbind(curr, pkg_v, status = "current")
+
+    keep_columns <- c("package", "mtime", "version", "uname", "size", "status")
+    x[, keep_columns]
+    rownames(x) <- NULL
+    x
+}
+
+arch2m <- function(arch){
+    if (!length(arch)) {
+        return(NULL)
+    }
+
+    l <- lapply(arch, function(x){
+        as.matrix(x[, c("mtime", "size", "uname")])
+    })
+    mat <- do.call(rbind, l)
+    pkg_v <- str2mat(pattern = "(.+)_(.+)\\.tar\\.gz",
+                     x = rownames(mat),
+                     columns = c("package", "version"))
+    # cleaning captures
+    pkg_v[, "package"] <- basename(pkg_v[, "package"])
+
+    x <- cbind(mat, pkg_v, status = "archived")
+
+    keep_columns <- c("package", "mtime", "version", "uname", "size", "status")
+    x[, keep_columns]
+    rownames(x) <- NULL
+    x
+}
+
+arch2df <- function(x) {
+    x <- as.data.frame(x)
+    x$size <- as.numeric(x$size)
+    x$mtime <- as.POSIXct(x$mtime, tz = cran_tz)
+
+    # Arrange dates and data
+    keep_columns <- c("package", "mtime", "version", "uname", "size", "status")
+    x <- sort_by(x[, keep_columns, drop = FALSE], ~package + mtime)
+    colnames(x) <- c("Package", "Datetime", "Version", "User", "Size", "Status")
+    rownames(x) <- NULL
+    x
+}
+
+warnings_archive <- function(all_packages) {
+    # Rely on order of all_packages by date
+    dup_arch <- duplicated(all_packages[, c("package", "version")])
+    if (any(dup_arch)) {
+        warning("There are ", sum(dup_arch, na.rm = TRUE),
+                " packages both archived and published\n",
+                "This indicate manual CRAN intervention.",
+                call. = FALSE, immediate. = TRUE)
+    }
+    all_packages
+}

--- a/R/arch_utils.R
+++ b/R/arch_utils.R
@@ -57,7 +57,7 @@ arch2df <- function(x) {
 
     # Arrange dates and data
     keep_columns <- c("package", "mtime", "version", "uname", "size", "status")
-    x <- sort_by(x[, keep_columns, drop = FALSE], ~package + mtime)
+    x <- sort_by(x[, keep_columns, drop = FALSE], x[, c("package", "status", "mtime")])
     colnames(x) <- c("Package", "Datetime", "Version", "User", "Size", "Status")
     rownames(x) <- NULL
     x

--- a/R/base_alias.R
+++ b/R/base_alias.R
@@ -16,7 +16,7 @@ base_alias <- function(packages = NULL) {
                                r_os_alias(alias2df(tools::base_aliases_db())))
     alias <- get_package_subset("base_aliases", packages)
     if (first) {
-        check_alias(alias)
+        warnings_alias(alias)
     }
     as.data.frame(alias[, c("Package", "Source", "Target")])
 }

--- a/R/base_alias.R
+++ b/R/base_alias.R
@@ -11,6 +11,7 @@
 #' head(ba)
 base_alias <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
+    check_packages(packages)
     first <- empty_env("base_aliases") && is.null(packages)
     alias <- save_state("base_aliases",
                                r_os_alias(alias2df(tools::base_aliases_db())))

--- a/R/base_alias.R
+++ b/R/base_alias.R
@@ -11,7 +11,7 @@
 #' head(ba)
 base_alias <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
-    first <- check_env("base_aliases") && is.null(packages)
+    first <- empty_env("base_aliases") && is.null(packages)
     alias <- save_state("base_aliases",
                                r_os_alias(alias2df(tools::base_aliases_db())))
     alias <- get_package_subset("base_aliases", packages)

--- a/R/base_help.R
+++ b/R/base_help.R
@@ -23,7 +23,8 @@ base_help_pages_not_linked <- function() {
     pages <- merge(ubal, unique(rbl[, c(links_cols2, links_cols)]),
                    by.x = alias_cols, by.y = links_cols2,
                    all.x = TRUE, all.y = FALSE, sort = FALSE)
-    p <- sort_by(pages[is.na(pages$from_pkg), alias_cols, drop = FALSE], ~Package + Source )
+    p <- pages[is.na(pages$from_pkg), alias_cols, drop = FALSE]
+    p <- sort_by(p, p[, c("Package", "Source")])
     rownames(p) <- NULL
     p
 }
@@ -52,7 +53,8 @@ base_help_pages_wo_links <- function() {
     pages2 <- merge(ubal, unique(rbl[, c(links_cols, links_cols2)]),
                     by.x = alias_cols, by.y = links_cols,
                     all.x = TRUE, all.y = FALSE, sort = FALSE)
-    p <- sort_by(pages2[is.na(pages2$to_pkg), alias_cols, drop = FALSE], ~Package + Source )
+    p <- pages2[is.na(pages2$from_pkg), alias_cols, drop = FALSE]
+    p <- sort_by(p, p[, c("Package", "Source")])
     rownames(p) <- NULL
     p
 }
@@ -92,7 +94,7 @@ base_help_cliques <- function() {
     df$clique <- rep(seq_len(length(lengths_graph2)), times = lengths_graph2)
     m <- merge(df, unique(rbl[, -4]), all.x = TRUE,
                by = c("from_pkg", "from_Rd"), sort = FALSE)
-    msorted <- sort_by(m, ~clique + from_pkg + from_Rd)
+    msorted <- sort_by(m, m[, c("clique", "from_pkg", "from_Rd")])
     rownames(msorted) <- NULL
     msorted
 }

--- a/R/base_xrefs.R
+++ b/R/base_xrefs.R
@@ -13,6 +13,7 @@
 base_links <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
     save_state("base_rdxrefs", xrefs2df(tools::base_rdxrefs_db()))
+    check_packages(packages, NA)
     links <- get_package_subset("base_rdxrefs", packages)
     as.data.frame(links)[, c("Package", "Source", "Target", "Anchor")]
 }
@@ -29,6 +30,7 @@ base_links <- function(packages = NULL) {
 #' head(btl)
 base_targets_links <- function(packages = NULL) {
     out <- NULL
+    check_packages(packages, NA)
     out <- save_state("base_targets_links", out, verbose = FALSE)
     if (is.null(out)) {
         bl <- base_links()
@@ -62,6 +64,7 @@ base_targets_links <- function(packages = NULL) {
 #' head(bpl)
 base_pages_links <- function(packages = NULL) {
     target_links <- save_state("base_targets_links", base_targets_links())
+    check_packages(packages, NA)
     w <- which(colnames(target_links) %in% "to_target")
     keep_rows <- nzchar(target_links$to_pkg)
     if (!is.null(packages)) {
@@ -83,6 +86,7 @@ base_pages_links <- function(packages = NULL) {
 #' head(bpkl)
 base_pkges_links <- function(packages = NULL) {
     target_links <- save_state("base_targets_links", base_targets_links())
+    check_packages(packages, NA)
     w <- which(!colnames(target_links) %in% c("from_pkg", "to_pkg", "n"))
     keep_rows <- nzchar(target_links$to_pkg)
     if (!is.null(packages)) {

--- a/R/base_xrefs.R
+++ b/R/base_xrefs.R
@@ -89,5 +89,5 @@ base_pkges_links <- function(packages = NULL) {
         keep_rows <- keep_rows & target_links %in% packages
     }
     pkges_links <- add_uniq_count(target_links[keep_rows, -w])
-    sort_by(pkges_links, ~from_pkg + n)
+    sort_by(pkges_links, pkges_links[, c("from_pkg", "n")])
 }

--- a/R/bioconductor.R
+++ b/R/bioconductor.R
@@ -62,9 +62,10 @@ bioc_repos <- function(version = "release",
 bioc_available <- function(version = "release",
                            repos = c("/bioc", "/data/annotation", "/data/experiment", "/workflows", "/books")) {
     url_repos <- bioc_repos(version, repos)
+    opts <- options(available_packages_filters = c("CRAN", "duplicates"))
+    on.exit(options(opts), add = TRUE)
     bioc <- save_state(paste0("bioc_available_", version),
-                       available.packages(filters = c("CRAN", "duplicates"),
-                                          repos = url_repos))
+        available.packages(repos = url_repos))
     bioc <- as.data.frame(bioc)
     bioc
 }

--- a/R/cran_actions.R
+++ b/R/cran_actions.R
@@ -10,8 +10,8 @@
 #' @importFrom utils head
 #' @keywords internal
 cran_actions <- function(packages = NULL, silent = FALSE) {
-    save_state("cran_action", cran_all_actions())
-    actions <- get_package_subset("cran_actions", packages)
+    save_state("full_cran_actions", cran_all_actions())
+    actions <- get_package_subset("full_cran_actions", packages)
     first_package <- !duplicated(actions$Package)
 
     if (isTRUE(silent)) {
@@ -21,8 +21,8 @@ cran_actions <- function(packages = NULL, silent = FALSE) {
 }
 
 cran_all_actions <- function() {
-    if (!empty_env("cran_actions")) {
-        return(pkg_state[["cran_actions"]])
+    if (!empty_env("full_cran_actions")) {
+        return(pkg_state[["full_cran_actions"]])
     }
 
     actions_f <- system.file(package = "repo.data", "data", "actions.rds")
@@ -41,7 +41,7 @@ cran_all_actions <- function() {
     actions$Package <- as.factor(actions$Package)
     actions <- sort_by(actions, ~Package + datetime2POSIXct(Date, Time) + Action)
     rownames(actions) <- NULL
-    pkg_state[["cran_actions"]] <- actions
+    pkg_state[["full_cran_actions"]] <- actions
     actions
 }
 

--- a/R/cran_actions.R
+++ b/R/cran_actions.R
@@ -11,6 +11,7 @@
 #' @keywords internal
 cran_actions <- function(packages = NULL, silent = FALSE) {
     save_state("full_cran_actions", cran_all_actions())
+    check_packages(packages, NA)
     actions <- get_package_subset("full_cran_actions", packages)
     first_package <- !duplicated(actions$Package)
 

--- a/R/cran_actions.R
+++ b/R/cran_actions.R
@@ -21,7 +21,7 @@ cran_actions <- function(packages = NULL, silent = FALSE) {
 }
 
 cran_all_actions <- function() {
-    if (!check_env("cran_actions")) {
+    if (!empty_env("cran_actions")) {
         return(pkg_state[["cran_actions"]])
     }
 

--- a/R/cran_alias.R
+++ b/R/cran_alias.R
@@ -7,7 +7,7 @@
 #' @family alias
 #' @seealso The raw source of the data is: \code{\link[tools:CRAN_aliases_db]{CRAN_aliases_db()}}.
 #' @examples
-#' ca <- cran_alias()
+#' ca <- cran_alias("BWStest")
 #' head(ca)
 cran_alias <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())

--- a/R/cran_alias.R
+++ b/R/cran_alias.R
@@ -13,6 +13,7 @@ cran_alias <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
     stopifnot("NULL or a character string" = is.null(packages) || is.character(packages))
     raw_alias <- save_state("cran_aliases", tools::CRAN_aliases_db())
+    check_packages(packages, NA)
     # Place to store modified data
     env <- "full_cran_aliases"
     # Check for random packages

--- a/R/cran_alias.R
+++ b/R/cran_alias.R
@@ -50,7 +50,7 @@ cran_alias <- function(packages = NULL) {
     # Add new package's data
     if (length(new_packages)) {
         new_alias <- alias2df(raw_alias[new_packages])
-        check_alias(new_alias)
+        warnings_alias(new_alias)
         alias <- rbind(alias, new_alias)
         pkg_state[[env]] <- alias[, c("Package", "Source", "Target")]
     }

--- a/R/cran_alias.R
+++ b/R/cran_alias.R
@@ -54,6 +54,9 @@ cran_alias <- function(packages = NULL) {
         alias <- rbind(alias, new_alias)
         pkg_state[[env]] <- alias[, c("Package", "Source", "Target")]
     }
-
-    as.data.frame(alias[alias[, "Package"] %in% packages, ])
+    if (is.null(packages)) {
+        as.data.frame(alias)
+    } else {
+        as.data.frame(alias[alias[, "Package"] %in% packages, , drop = FALSE])
+    }
 }

--- a/R/cran_archive.R
+++ b/R/cran_archive.R
@@ -17,7 +17,7 @@
 #'  For some dates and comments about archiving packages: [cran_comments()].
 #' @examples
 #' \donttest{
-#' ca <- cran_archive()
+#' ca <- cran_archive("A3")
 #' head(ca)
 #' }
 cran_archive <- function(packages = NULL) {

--- a/R/cran_archive.R
+++ b/R/cran_archive.R
@@ -51,13 +51,13 @@ cran_archive <- function(packages = NULL) {
 
     # Decide which packages are to be added to the data
     if (!is.null(packages) & !first_arch) {
-        new_packages <- setdiff(packages, arch[, "package"])
+        new_packages <- setdiff(packages, arch[, "Package"])
     } else if (!is.null(packages) & first_arch) {
         new_packages <- intersect(packages, all_names)
     } else if (is.null(packages) & first_arch) {
         new_packages <- all_names
     } else if (is.null(packages) & !first_arch) {
-        new_packages <- setdiff(all_names, arch[, "package"])
+        new_packages <- setdiff(all_names, arch[, "Package"])
     }
 
     # Add new package's data
@@ -72,7 +72,7 @@ cran_archive <- function(packages = NULL) {
     if (is.null(packages)) {
         arch2df(arch)
     } else {
-        arch2df(arch[arch[, "package"] %in% packages, , drop = FALSE])
+        arch2df(arch[arch[, "Package"] %in% packages, , drop = FALSE])
     }
 }
 

--- a/R/cran_archive.R
+++ b/R/cran_archive.R
@@ -69,7 +69,7 @@ cran_archive <- function(packages = NULL) {
         pkg_state[[env]] <- arch
     }
 
-    if (is.null(packages)) {
+    if (length(new_packages)) {
         arch2df(arch)
     } else {
         arch2df(arch[arch[, "Package"] %in% packages, , drop = FALSE])

--- a/R/cran_archive.R
+++ b/R/cran_archive.R
@@ -30,7 +30,7 @@ cran_archive <- function(packages = NULL) {
 cran_pkges_archive <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
     # Check if package is there
-    if (!check_env("cran_archive")) {
+    if (!empty_env("cran_archive")) {
         out <- get_package_subset("cran_archive", packages)
         if (check_subset(out, packages)) {
             warnings_archive(out)

--- a/R/cran_comments.R
+++ b/R/cran_comments.R
@@ -24,6 +24,7 @@
 #' }
 cran_comments <- function(packages = NULL) {
     save_state("cran_comments", cran_all_comments(), verbose = FALSE)
+    check_packages(packages, NA)
     get_package_subset("cran_comments", packages)
 }
 

--- a/R/cran_comments.R
+++ b/R/cran_comments.R
@@ -35,7 +35,7 @@ cran_all_comments <- function() {
     history_df <- extract_field(file, field = "X-CRAN-History")
     full_history <- rbind(comments_df, history_df)
 
-    fh <- sort_by(full_history, ~package + date)
+    fh <- sort_by(full_history, full_history[, c("package", "date")])
     edit <- !endsWith(fh$action, "ed")
     fh$action[edit & !is.na(edit)] <- paste0(fh$action[edit & !is.na(edit)], "d")
     rownames(fh) <- NULL

--- a/R/cran_help.R
+++ b/R/cran_help.R
@@ -86,7 +86,8 @@ cran_help_cliques <- function(packages = NULL) {
     }
     if (!is.null(packages)) {
         pkges <- tools::package_dependencies(packages, which = "all",
-                                             reverse = TRUE, recursive = FALSE)
+                                             reverse = TRUE, recursive = FALSE,
+                                             db = available.packages())
     } else {
         pkges <- NULL
     }

--- a/R/cran_help.R
+++ b/R/cran_help.R
@@ -8,10 +8,16 @@
 #' @export
 #' @family cran_help_pages
 #' @examples
-#' chnl <- cran_help_pages_not_linked("A3")
+#' ap <- available.packages()
+#' a_package <- rownames(ap)[startsWith(rownames(ap), "A")][1]
+#' chnl <- cran_help_pages_not_linked(a_package)
 #' head(chnl)
 cran_help_pages_not_linked <- function(packages = NULL) {
-    cal <- cran_alias(packages)
+    check_packages(packages)
+    cal <-  cran_alias(packages)
+    if (!NROW(cal)) {
+        stop("Package not found")
+    }
     # cl <- cran_links()
     rbl <- save_state("cran_targets_links", cran_targets_links(), verbose = FALSE)
     if (!is.null(packages)) {
@@ -44,10 +50,12 @@ cran_help_pages_not_linked <- function(packages = NULL) {
 #' @export
 #' @family cran_help_pages
 #' @examples
-#' chwl <- cran_help_pages_wo_links("A3")
+#' ap <- available.packages()
+#' a_package <- rownames(ap)[startsWith(rownames(ap), "a")][1]
+#' chwl <- cran_help_pages_wo_links(a_package)
 #' head(chwl)
 cran_help_pages_wo_links <- function(packages = NULL) {
-
+    check_packages(packages)
     cal <- cran_alias(packages)
     # cl <- cran_links()
     rbl <- save_state("cran_targets_links", cran_targets_links(), verbose = FALSE)
@@ -81,9 +89,12 @@ cran_help_pages_wo_links <- function(packages = NULL) {
 #' chc <- cran_help_cliques("DZEXPM")
 #' head(chc)
 cran_help_cliques <- function(packages = NULL) {
+    check_packages(packages)
     if (!check_installed("igraph")) {
         stop("This function requires igraph to find help pages not linked to the network.")
     }
+    opts <- options(available_packages_filters = c("CRAN", "duplicates"))
+    on.exit(options(opts), add = TRUE)
     if (!is.null(packages)) {
         pkges <- tools::package_dependencies(packages, which = "all",
                                              reverse = TRUE, recursive = FALSE,
@@ -125,6 +136,6 @@ cran_help_cliques <- function(packages = NULL) {
 
 # Identify packages with cross-references to pages of packages they do not depend to.
 cran_help_pages_links_wo_deps <- function() {
-    ap <- available.packages(filters = c("CRAN", "duplicates"))
+    ap <- available.packages()
     xrefs_wo_deps(cran_links(), ap[, check_which("strong")])
 }

--- a/R/cran_help.R
+++ b/R/cran_help.R
@@ -30,7 +30,7 @@ cran_help_pages_not_linked <- function(packages = NULL) {
         keep <-  keep & pages$to_pkg %in% packages
     }
     pages2 <- pages[, alias_cols, drop = FALSE]
-    p <- sort_by(pages2, ~Package + Source )
+    p <- sort_by(pages2, pages2[, c("Package", "Source")] )
     rownames(p) <- NULL
     p
 }
@@ -61,7 +61,8 @@ cran_help_pages_wo_links <- function(packages = NULL) {
     pages2 <- merge(ubal, unique(rbl[, c(links_cols, "to_pkg", "to_Rd")]),
                     by.x = alias_cols, by.y = links_cols,
                     all.x = TRUE, all.y = FALSE, sort = FALSE)
-    p <- sort_by(pages2[is.na(pages2$to_pkg), alias_cols, drop = FALSE], ~Package + Source )
+    p <- pages2[is.na(pages2$to_pkg), alias_cols, drop = FALSE]
+    p <- sort_by(p, p[, c("Package", "Source")])
     rownames(p) <- NULL
     p
 }
@@ -73,10 +74,11 @@ cran_help_pages_wo_links <- function(packages = NULL) {
 #' Requires igraph
 #' @inheritParams base_alias
 #' @returns Return a data.frame of help pages not connected to the network of help pages.
+#' Or NULL if nothing are found.
 #' @family cran_help_pages
 #' @export
 #' @examples
-#' chc <- cran_help_cliques()
+#' chc <- cran_help_cliques("DZEXPM")
 #' head(chc)
 cran_help_cliques <- function(packages = NULL) {
     if (!check_installed("igraph")) {
@@ -95,6 +97,9 @@ cran_help_cliques <- function(packages = NULL) {
     cal <- cal[cal$from_pkg %in% pkges | (!is.na(cal$to_pkg) & cal$to_pkg %in% packages), ]
     # Filter out those links not resolved
     cal <- cal[nzchar(cal$to_Rd) & nzchar(cal$from_Rd), ]
+    if (!nrow(cal)) {
+        return(NULL)
+    }
     df_links <- data.frame(from = paste0(cal$from_pkg, ":", cal$from_Rd),
                            to = paste0(cal$to_pkg, ":", cal$to_Rd))
     df_links <- unique(df_links)

--- a/R/cran_history.R
+++ b/R/cran_history.R
@@ -32,7 +32,7 @@ cran_all_history <- function() {
                 all = TRUE, by = c("Version", "Package"),
                 sort = FALSE, suffixes = c("", ".archive"))
     m0$moment <- datetime2POSIXct(m0$Date, m0$Time)
-    m0 <- sort_by(m0, ~Package + moment + Action)
+    m0 <- sort_by(m0, m0[, c("Package", "moment", "Action")])
 
     # Published date is later than what the archive says
     k4 <- m0$Action == "publish" & m0$Date > m0$Date.archive & !is.na(m0$Date) & !is.na(m0$Date.archive)
@@ -47,7 +47,7 @@ cran_all_history <- function() {
 
     # Fill the gaps from previous action if possible
     m0$moment <- datetime2POSIXct(m0$Date, m0$Time)
-    m0 <- sort_by(m0, ~Package + moment + Action)
+    m0 <- sort_by(m0, m0[, c("Package", "moment", "Action")])
 
     # Use version of the previously published package
     wo_version <- which(is.na(m0$Version))
@@ -79,7 +79,7 @@ cran_all_history <- function() {
     m <- merge(published, archived, all = TRUE, sort = FALSE)
     m$Pub.Date <- datetime2POSIXct(m$Date.Pub, m$Time.Pub)
     m$Arch.Date <- datetime2POSIXct(m$Date.Arch, m$Time.Arch)
-    m <- sort_by(m, ~Package + Pub.Date + Arch.Date)
+    m <- sort_by(m, m[, c("Package", "Pub.Date", "Arch.Date")])
 
     # TODO: Find the dates of previous publish actions to use as archive date
     lapply(unique(m$package), function(i, data) {

--- a/R/cran_history.R
+++ b/R/cran_history.R
@@ -14,6 +14,7 @@
 #' cran_history
 cran_history <- function(packages = NULL) {
     save_state("cran_history", cran_all_history())
+    check_packages(packages, NA)
     get_package_subset("cran_history", packages)
 }
 

--- a/R/cran_history.R
+++ b/R/cran_history.R
@@ -18,8 +18,8 @@ cran_history <- function(packages = NULL) {
 }
 
 cran_all_history <- function() {
-    archive <- save_state("cran_archive", cran_archive())
-    actions <- save_state("cran_actions", cran_actions())
+    archive <- save_state("full_cran_archive", cran_archive())
+    actions <- save_state("full_cran_actions", cran_actions())
     # comments <- save_state("cran_comments", cran_comments())
 
     archive$Date <- strftime(archive$Datetime, "%F")

--- a/R/cran_snapshot.R
+++ b/R/cran_snapshot.R
@@ -15,12 +15,12 @@ cran_snapshot <- function(date) {
 
     stopifnot("Provide a date" = is(date, "Date"),
               "Accepted ranges is from the beginning of CRAN to today" = date <= Sys.Date() || date >= as.Date("1997-10-08"))
-    ca <- save_state("full_cran_archive", cran_archive())
+    ca <- save_state("full_cran_archive", cran_archive(), verbose = FALSE)
     if (date == Sys.Date()) {
         return(ca[ca$status == "current", ])
     }
 
-    ca <- sort_by(ca, ~Package + Datetime)
+    ca <- sort_by(ca, ca[, c("Package", "Datetime")])
     ca_before <- ca[as.Date(ca$Datetime) <= date, , drop = TRUE]
 
     # Remove duplicated packages from the last to keep the latest version
@@ -35,7 +35,7 @@ cran_snapshot <- function(date) {
     }
 
     cc_archive <- cc[cc$action %in% c("archived", "removed") & cc$date <= date, ]
-    cc_archive <- sort_by(cc_archive, ~package + date)
+    cc_archive <- sort_by(cc_archive, cc_archive[, c("package", "date")])
     dups <- duplicated(cc_archive$package, fromLast = TRUE)
     last_archival <- cc_archive[!dups & !is.na(cc_archive$package), ]
 
@@ -80,11 +80,6 @@ cran_date <- function(versions) {
     if (!nrow(ca_packages)) {
         warning("No packages on CRAN to find a date.")
         return(NA)
-    }
-    ca_packages <- get_package_subset("cran_archive", versions[, "Package"])
-    if (is.null(ca_packages)) {
-        ca <- save_state("full_cran_archive", cran_archive())
-        ca_packages <- ca[ca$Package %in% versions[, "Package"], , drop = FALSE]
     }
     versions[, "Version"] <- as.character(versions[, "Version"])
     # match packages names and versions

--- a/R/cran_snapshot.R
+++ b/R/cran_snapshot.R
@@ -14,7 +14,7 @@ cran_snapshot <- function(date) {
 
     stopifnot("Provide a date" = is(date, "Date"),
               "Accepted ranges is from the beginning of CRAN to today" = date <= Sys.Date() || date >= as.Date("1997-10-08"))
-    ca <- save_state("cran_archive", cran_archive())
+    ca <- save_state("full_cran_archive", cran_archive())
     if (date == Sys.Date()) {
         return(ca[ca$status == "current", ])
     }
@@ -82,7 +82,7 @@ cran_date <- function(versions) {
     }
     ca_packages <- get_package_subset("cran_archive", versions[, "Package"])
     if (is.null(ca_packages)) {
-        ca <- save_state("cran_archive", cran_archive())
+        ca <- save_state("full_cran_archive", cran_archive())
         ca_packages <- ca[ca$Package %in% versions[, "Package"], , drop = FALSE]
     }
     versions[, "Version"] <- as.character(versions[, "Version"])

--- a/R/cran_snapshot.R
+++ b/R/cran_snapshot.R
@@ -9,7 +9,8 @@
 #' @export
 #'
 #' @examples
-#' cran_snapshot(Sys.Date() -2 )
+#' cs <- cran_snapshot(Sys.Date() -2 )
+#' head(cs)
 cran_snapshot <- function(date) {
 
     stopifnot("Provide a date" = is(date, "Date"),

--- a/R/cran_snapshot.R
+++ b/R/cran_snapshot.R
@@ -2,7 +2,8 @@
 #'
 #' Given the available information which packages were on CRAN on a given date?
 #' @note Due to missing of CRAN comments some packages are not annotated when
-#' were they archived and more packages will be returned for any given date.
+#' were they archived and more packages than present might be returned for any
+#' given date.
 #' @param date The date you want to check.
 #'
 #' @returns The data.frame with the packages and versions at a given date.
@@ -50,7 +51,9 @@ cran_snapshot <- function(date) {
     on_cran <- rep_len(TRUE, nrow(ca_before_date))
     names(on_cran) <- ca_before_date$package
     on_cran[na.omit(archived)] <- as.Date(ca_before_date$Datetime[na.omit(archived)]) > last_archival$date[!is.na(archived)]
-    ca_before_date[on_cran, ]
+    out <- ca_before_date[on_cran, ]
+    rownames(out) <- NULL
+    out
 }
 
 

--- a/R/cran_snapshot.R
+++ b/R/cran_snapshot.R
@@ -16,14 +16,14 @@ cran_snapshot <- function(date) {
 
     stopifnot("Provide a date" = is(date, "Date"),
               "Accepted ranges is from the beginning of CRAN to today" = date <= Sys.Date() || date >= as.Date("1997-10-08"))
-    ca <- save_state("full_cran_archive", cran_archive(), verbose = FALSE)
+    
+    ca <- cran_archive()
     if (date == Sys.Date()) {
         return(ca[ca$status == "current", ])
     }
     if (is.null(ca)) {
         return(NULL)
     }
-
     ca <- sort_by(ca, ca[, c("Package", "Datetime"), drop = FALSE])
     ca_before <- ca[as.Date(ca$Datetime) <= date, , drop = TRUE]
 
@@ -31,7 +31,7 @@ cran_snapshot <- function(date) {
     dups <- duplicated(ca_before$Package, fromLast = TRUE)
     ca_before_date <- ca_before[!dups, c("Package", "Version", "Datetime", "Status")]
 
-    cc <- save_state("cran_comments", cran_comments())
+    cc <- cran_comments()
 
     # If date is earlier than any comments return what it was.
     if (date < min(cc$date, na.rm = TRUE)) {

--- a/R/cran_snapshot.R
+++ b/R/cran_snapshot.R
@@ -19,8 +19,11 @@ cran_snapshot <- function(date) {
     if (date == Sys.Date()) {
         return(ca[ca$status == "current", ])
     }
+    if (is.null(ca)) {
+        return(NULL)
+    }
 
-    ca <- sort_by(ca, ca[, c("Package", "Datetime")])
+    ca <- sort_by(ca, ca[, c("Package", "Datetime"), drop = FALSE])
     ca_before <- ca[as.Date(ca$Datetime) <= date, , drop = TRUE]
 
     # Remove duplicated packages from the last to keep the latest version

--- a/R/cran_xrefs.R
+++ b/R/cran_xrefs.R
@@ -12,7 +12,7 @@
 #' head(cl)
 cran_links <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
-    first <- check_env("cran_rdxrefs") && is.null(packages)
+    first <- empty_env("cran_rdxrefs") && is.null(packages)
     save_state("cran_rdxrefs", xrefs2df(tools::CRAN_rdxrefs_db()))
     cr <- get_package_subset("cran_rdxrefs", packages)
     if (first) {

--- a/R/cran_xrefs.R
+++ b/R/cran_xrefs.R
@@ -13,6 +13,7 @@
 cran_links <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
     raw_xrefs <- save_state("cran_rdxrefs", tools::CRAN_rdxrefs_db())
+    check_packages(packages, NA)
     env <- "full_cran_rdxrefs"
     # Check for random packages
     current_packages <- names(raw_xrefs)
@@ -73,6 +74,7 @@ cran_links <- function(packages = NULL) {
 cran_targets_links <- function(packages = NULL) {
     out <- NULL
     out <- save_state("cran_targets_links", out, verbose = FALSE)
+    check_packages(packages, NA)
     if (is.null(out)) {
         bal <- base_alias()
         cal <- cran_alias()
@@ -104,6 +106,7 @@ cran_targets_links <- function(packages = NULL) {
 #' cpl <- cran_pages_links()
 #' head(cpl)
 cran_pages_links <- function(packages = NULL) {
+    check_packages(packages, NA)
     target_links <- save_state("cran_targets_links", cran_targets_links(packages))
     w <- which(colnames(target_links) %in% "to_target")
     keep_rows <- nzchar(target_links$to_pkg)
@@ -126,6 +129,7 @@ cran_pages_links <- function(packages = NULL) {
 #' head(cpkl)
 cran_pkges_links <- function(packages = NULL) {
     target_links <- save_state("cran_pages_links", base_targets_links())
+    check_packages(packages, NA)
     w <- which(!colnames(target_links) %in% c("from_pkg", "to_pkg"))
     keep_rows <- nzchar(target_links$to_pkg)
     if (!is.null(packages)) {

--- a/R/cran_xrefs.R
+++ b/R/cran_xrefs.R
@@ -13,9 +13,8 @@
 cran_links <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
     first <- empty_env("cran_rdxrefs") && is.null(packages)
-    save_state("cran_rdxrefs", tools::CRAN_rdxrefs_db())
-    env <- "full_cran_rdxrefs"
     raw_xrefs <- save_state("cran_rdxrefs", tools::CRAN_rdxrefs_db())
+    env <- "full_cran_rdxrefs"
     # Check for random packages
     current_packages <- names(raw_xrefs)
     omit_pkg <- setdiff(packages, current_packages)

--- a/R/cran_xrefs.R
+++ b/R/cran_xrefs.R
@@ -8,7 +8,7 @@
 #' @seealso The raw source of the data is: \code{\link[tools:CRAN_rdxrefs_db]{CRAN_rdxrefs_db()}}.
 #' @export
 #' @examples
-#' cl <- cran_links()
+#' cl <- cran_links("CytoSimplex")
 #' head(cl)
 cran_links <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
@@ -49,7 +49,7 @@ cran_links <- function(packages = NULL) {
     # Add new package's data
     if (length(new_packages)) {
         new_xrefs <- xrefs2df(raw_xrefs[new_packages])
-        # check_links(new_xrefs)
+        # warnings_links(new_xrefs)
         xrefs <- rbind(xrefs, new_xrefs)
         pkg_state[[env]] <- xrefs[, c("Package", "Source", "Anchor", "Target")]
     }

--- a/R/cran_xrefs.R
+++ b/R/cran_xrefs.R
@@ -12,7 +12,6 @@
 #' head(cl)
 cran_links <- function(packages = NULL) {
     stopifnot("Requires at least R 4.5.0" = check_r_version())
-    first <- empty_env("cran_rdxrefs") && is.null(packages)
     raw_xrefs <- save_state("cran_rdxrefs", tools::CRAN_rdxrefs_db())
     env <- "full_cran_rdxrefs"
     # Check for random packages

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -70,8 +70,8 @@ package_dependencies <- function(pkg = ".", which = "strong") {
     }
     pkgs_n_fields <- all_deps_df$type %in% fields_selected & all_deps_df$package %in% deps_available
     rd <- all_deps_df[pkgs_n_fields, , drop = FALSE]
-
-    rd2 <- sort_by(unique(rd[, c(1, 3)]), ~name + version)
+    rd2 <- unique(rd[, c(1, 3)])
+    rd2 <- sort_by(rd2, rd2[, c("name", "version")])
     s <- split(rd2$version, rd2$name)
     v <- lapply(s, function(x){
         y <- x[!is.na(x)]
@@ -145,7 +145,7 @@ packages_dependencies <- function(ap) {
     df <- as.data.frame(m_all)
     # Conversion to package_version class because currently we can do it.
     df$version <- package_version(df$version)
-    df <- sort_by(df, ~package + type + name)
+    df <- sort_by(df, df[, c("package", "type", "name")])
     rownames(df) <- NULL
     df
 }

--- a/R/package_dependencies.R
+++ b/R/package_dependencies.R
@@ -1,0 +1,3 @@
+# package_dependencies <- function(){
+#
+# }

--- a/R/repos.R
+++ b/R/repos.R
@@ -17,7 +17,9 @@
 pkges_repos <- function(repos = getOption("repos"), which = "all") {
     stopifnot(is.character(repos) && length(repos))
     which <- check_which(which)
-    ap <- available.packages(repos = repos, filters = "duplicates")
+    opts <- options(available_packages_filters = c("CRAN", "duplicates"))
+    on.exit(options(opts), add = TRUE)
+    ap <- available.packages(repos = repos)
     repositories <- gsub("/src/contrib", "", ap[, "Repository"], fixed = TRUE)
     repositories_names <- names(repos)[match(repositories, repos)]
     packages <- ap[, "Package"]

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,9 +3,11 @@ empty_env <- function(name) {
 }
 
 save_state <- function(name, out, verbose = TRUE) {
+    # Use CRAN mirror if not set a default
+    CRAN_baseurl()
     if (empty_env(name)) {
         if (verbose) {
-        message("Retrieving ", name, ", this might take a bit. ",
+        message("Retrieving ", name, ", this might take a bit.\n",
                 "Caching results to be faster next call in this session.")
         }
         pkg_state[[name]] <- out
@@ -26,16 +28,19 @@ get_package_subset <- function(name, pkges) {
         if (is.null(pkges)) {
             return(df)
         }
-        if ("package" %in% colnames(df)) {
-            df[df[, "package"] %in% pkges, , drop = FALSE]
-        } else {
-            df[df[, "Package"] %in% pkges, , drop = FALSE]
-        }
+        df[pkg_in_x(df, pkges), , drop = FALSE]
     } else {
         NULL
     }
 }
 
+pkg_in_x <- function(x, packages) {
+    if ("package" %in% colnames(x)) {
+        x[, "package"] %in% packages
+    } else {
+        x[, "Package"] %in% packages
+    }
+}
 check_subset <- function(obj, pkges) {
     if ("package" %in% colnames(obj)) {
         all(pkges %in% obj[, "package"])
@@ -50,7 +55,7 @@ check_installed <- function(x) {
 
 # tools:::CRAN_baseurl_for_src_area but with fixed mirror
 CRAN_baseurl <- function() {
-    Sys.getenv("R_CRAN_SRC", "https://CRAN.R-project.org")
+    Sys.setenv(R_CRAN_SRC = Sys.getenv("R_CRAN_SRC", "https://CRAN.R-project.org"))
 }
 
 # tools:::read_CRAN_object but for several types

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,7 +55,13 @@ check_installed <- function(x) {
 
 # tools:::CRAN_baseurl_for_src_area but with fixed mirror
 CRAN_baseurl <- function() {
-    Sys.setenv(R_CRAN_SRC = Sys.getenv("R_CRAN_SRC", "https://CRAN.R-project.org"))
+    url <- "https://CRAN.R-project.org"
+    out <- Sys.setenv(R_CRAN_SRC = Sys.getenv("R_CRAN_SRC", url))
+    if (isTRUE(out)) {
+        url
+    } else {
+        NULL
+    }
 }
 
 # tools:::read_CRAN_object but for several types

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,6 +53,19 @@ check_installed <- function(x) {
     requireNamespace(x, quietly = TRUE)
 }
 
+check_local <- function(x) {
+    desc_pkg <- file.path(x, "DESCRIPTION")
+    local_pkg <- file.exists(desc_pkg)
+    if (any(local_pkg) && sum(local_pkg) > 1L) {
+        stop(
+            "This function only allows to use one local package",
+            .call = FALSE
+        )
+    } else {
+        desc_pkg
+    }
+}
+
 # tools:::CRAN_baseurl_for_src_area but with fixed mirror
 CRAN_baseurl <- function() {
     url <- "https://CRAN.R-project.org"
@@ -132,4 +145,23 @@ add_uniq_count <- function(x, name = "n", old_name = "n") {
     out$n <- as.numeric(out$n)
     rownames(out) <- NULL
     out
+}
+
+check_packages <- function(packages, length = 1L) {
+    check <- if (is.null(packages)) {
+        TRUE
+    }  else {
+        is.character(packages) && length(na.omit(packages)) <= length
+    }
+
+    if (isFALSE(check)) {
+        arbitrary_length <- is.na(length) || length == 0L
+        msg <- if (arbitrary_length) {
+            "Use NULL or a character vector."
+        } else {
+            sprintf("Use NULL or a character vector (without NA) of length %d.", length)
+        }
+        stop(msg, call. = FALSE)
+    }
+    check
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,9 +1,9 @@
-check_env <- function(name) {
+empty_env <- function(name) {
     is.null(pkg_state[[name]])
 }
 
 save_state <- function(name, out, verbose = TRUE) {
-    if (check_env(name)) {
+    if (empty_env(name)) {
         if (verbose) {
         message("Retrieving ", name, ", this might take a bit. ",
                 "Caching results to be faster next call in this session.")
@@ -20,7 +20,7 @@ get_package_subset <- function(name, pkges) {
     stopifnot(is.character(name) && length(name) == 1L,
               "NULL or character vector" = is.null(pkges) || (is.character(pkges) && length(pkges)))
 
-    if (!check_env(name)) {
+    if (!empty_env(name)) {
         df <- pkg_state[[name]]
 
         if (is.null(pkges)) {

--- a/R/xrefs_utils.R
+++ b/R/xrefs_utils.R
@@ -1,4 +1,3 @@
-
 xrefs2df <- function(x) {
     if (!length(x)) {
         return(NULL)
@@ -181,4 +180,3 @@ pkgs_linked_missing <- function(links, alias) {
     rownames(links2) <- NULL
     links2
 }
-

--- a/R/xrefs_utils.R
+++ b/R/xrefs_utils.R
@@ -1,10 +1,13 @@
 
 xrefs2df <- function(x) {
+    if (!length(x)) {
+        return(NULL)
+    }
+
     rdxrefsDF <- do.call(rbind, x)
     rdxrefsDF <- cbind(rdxrefsDF, Package = rep(names(x), vapply(x, NROW, numeric(1L))))
     rownames(rdxrefsDF) <- NULL
     rdxrefsDF[, c("Package", "Source", "Anchor", "Target"), drop = FALSE]
-    rdxrefsDF
 }
 
 split_anchor <- function(links) {

--- a/R/xrefs_utils.R
+++ b/R/xrefs_utils.R
@@ -140,7 +140,8 @@ targets2files <- function(links, alias) {
     colnames(links_w_files) <- c("to_pkg", "to_target", "from_pkg", "from_Rd", "n", "to_Rd")
     links_w_files[is.na(links_w_files[, "to_Rd"]), "to_Rd"] <- ""
     links_w_files <- links_w_files[, c(3, 4, 1, 2, 6, 5)]
-    links_w_files <- sort_by(links_w_files, ~from_pkg+from_Rd+to_target+to_Rd)
+    links_w_files <- sort_by(links_w_files,
+                             links_w_files[, c("from_pkg", "from_Rd", "to_target", "to_Rd")])
     rownames(links_w_files) <- NULL
     links_w_files
 }

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@
 
 [![CRAN
 status](https://www.r-pkg.org/badges/version/repo.data)](https://CRAN.R-project.org/package=repo.data)
+[![R-CMD-check](https://github.com/llrs/repo.data/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/llrs/repo.data/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The goal of repo.data is to make repository data accessible. Mainly it
 consumes existing data but the idea is to also generate it.
+
+When a function is specific of a repository it will start with its name:
+`cran_` or `bioc_`.
 
 ## Installation
 
@@ -26,43 +30,43 @@ We can get a data.frame of all packages on CRAN archive:
 
 ``` r
 library(repo.data)
+#> Warning: Altering install.packages behavior!
 ca <- cran_archive()
+#> Warning: There are 5 packages both archived and published
+#> This indicate manual CRAN intervention.
 head(ca)
-#>         package      published_date version cran_team   size   status
-#> 1            A3 2013-02-07 09:00:29   0.9.1    hornik  45252 archived
-#> 2            A3 2013-03-26 18:58:40   0.9.2    ligges  45907 archived
-#> 3            A3 2015-08-16 21:05:54   1.0.0    hornik  42810  current
-#> 4 AalenJohansen 2023-03-01 10:42:11     1.0    ligges 165057  current
-#> 5          aaMI 2005-06-24 15:55:17   1.0-0      root   2968 archived
-#> 6          aaMI 2005-10-17 19:24:18   1.0-1      root   3487 archived
+#> [1] Package  Datetime Version  User     Size     Status  
+#> <0 rows> (or 0-length row.names)
 ```
 
 We can also check CRAN comments about the packages on its archive:
 
 ``` r
 cc <- cran_comments()
+#> Retrieving comments, this might take a bit.
+#> Caching results to be faster next call in this session.
 head(cc)
-#>       package
-#> 1       aaSEA
-#> 2         aba
-#> 3      abbyyR
-#> 4      abcADM
-#> 5    abcdeFBA
-#> 6 ABCExtremes
-#>                                                                                        comment
-#> 1               Archived on 2022-06-21 as check problems were not corrected despite reminders.
-#> 2                         Archived on 2022-03-27 as check problems were not corrected in time.
-#> 3                                          Archived on 2023-11-03 at the maintainer's request.
-#> 4                                 Archived on 2023-03-02 as issues were not corrected in time.
-#> 5                         Archived on 2022-03-07 as check problems were not corrected in time.
-#> 6 Archived on 2015-06-19 as incomplete maintainer address was not corrected despite reminders.
+#>    package
+#> 1       A3
+#> 2    aaSEA
+#> 3      aba
+#> 4   abbyyR
+#> 5   abcADM
+#> 6 abcdeFBA
+#>                                                                          comment
+#> 1         Archived on 2025-06-13 as issues were not corrected despite reminders.
+#> 2 Archived on 2022-06-21 as check problems were not corrected despite reminders.
+#> 3           Archived on 2022-03-27 as check problems were not corrected in time.
+#> 4                            Archived on 2023-11-03 at the maintainer's request.
+#> 5                   Archived on 2023-03-02 as issues were not corrected in time.
+#> 6           Archived on 2022-03-07 as check problems were not corrected in time.
 #>         date   action
-#> 1 2022-06-21 archived
-#> 2 2022-03-27 archived
-#> 3 2023-11-03 archived
-#> 4 2023-03-02 archived
-#> 5 2022-03-07 archived
-#> 6 2015-06-19 archived
+#> 1 2025-06-13 archived
+#> 2 2022-06-21 archived
+#> 3 2022-03-27 archived
+#> 4 2023-11-03 archived
+#> 5 2023-03-02 archived
+#> 6 2022-03-07 archived
 ```
 
 Or estimate the last date of update of our packages, by the information
@@ -70,10 +74,14 @@ on the session info or a data.frame:
 
 ``` r
 cran_session(session = sessionInfo())
-#> [1] "2024-11-08"
+#> Warning in cran_archive(versions[, "Package"]): Omitting packages repo.data.
+#> Maybe they were not on CRAN?
+#> [1] "2025-06-18"
 ip <- installed.packages()
 cran_date(ip)
-#> [1] "2024-12-08"
+#> Warning in cran_archive(versions[, "Package"]): Omitting packages repo.data, airway, alabaster.base, alabaster.matrix, alabaster.ranges, alabaster.sce, alabaster.schemas, alabaster.se, annotate, AnnotationDbi, AnnotationFilter, AnnotationHub, assorthead, Biobase, BiocFileCache, BiocGenerics, BiocIO, BioCor, BiocParallel, BiocPkgTools, BiocStyle, BiocVersion, biocViews, biomformat, Biostrings, cransays, DelayedArray, DESeq2, ensembldb, ExperimentHub, fgsea, GenomeInfoDb, GenomeInfoDbData, GenomicAlignments, GenomicFeatures, GenomicRanges, GO.db, GOSemSim, GSEABase, gypsum, h5mread, HDF5Array, IRanges, KEGGREST, MatrixGenerics, microshades, org.Hs.eg.db, phyloseq, preprocessCore, ProtGenerics, reactome.db, resios, rhdf5, rhdf5filters, Rhdf5lib, Rhtslib, rostemplate, rotemplate, Rsamtools, rtracklayer, rutils, S4Arrays, S4Vectors, scRNAseq, SingleCellExperiment, SparseArray, SummarizedExperiment, UCSC.utils, XVector.
+#> Maybe they were not on CRAN?
+#> [1] "2025-06-21"
 ```
 
 ## Related packages
@@ -81,11 +89,17 @@ cran_date(ip)
 Other packages and related analysis :
 
 - Task views: <https://github.com/epiverse-connect/ctv-analysis/>
-- static packages: [pkgstats](https://docs.ropensci.org/pkgstats)
+- static packages: [pkgstats](https://docs.ropensci.org/pkgstats/)
 - Bioconductor: biopkgtools
 - R-universe: universe
 - [cranly](https://cran.r-project.org/package=cranly): About package
   dependencies and authors of packages.
+- [versions](https://github.com/goldingn/versions): A package about
+  installing packages versions. `install.dates()` requires a CRAN date,
+  if you are unsure you can use `cran_date()` to estimate it given a
+  `library()` or a `sessionInfo` report.
+- [checkpoint](https://cran.r-project.org/package=checkpoint) provides
+  tools to ensure the results of R code are repeatable over time.
 
 ## History
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,5 @@
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* This is a new release.

--- a/data-raw/os_alias.R
+++ b/data-raw/os_alias.R
@@ -36,6 +36,7 @@ al_s <- read.table(text = "./base/man/unix/Signals.Rd:\alias{Signals}
 ./parallel/man/windows/mcdummies.Rd:\alias{mcmapply}
 ./parallel/man/windows/mcdummies.Rd:\alias{pvec}
 ", sep = ":")
+
 os_alias <- cbind(
     Package = basename(dirname(dirname(dirname(al_s$V1)))),
     os = basename(dirname(al_s$V1)),

--- a/inst/scripts/cran_actions.R
+++ b/inst/scripts/cran_actions.R
@@ -1,0 +1,122 @@
+actions_s2 <- actions_s[actions_s$Action != "remove", ]
+s_pkg <- split(actions_s2, actions_s2$Package)
+
+
+around_archive <- function(e) {
+    # Make sure data is sorted
+    e <- sort_by(e, ~Package + as.POSIXct(paste(Date, Time), tz = "UTC"))
+    pub <- e$Action == "publish"
+    arc <- e$Action == "archive"
+    pub_w <- which(pub)
+    arc_w <- which(arc)
+    # a <- rle(cumsum(arc))
+    # p <- rle(cumsum(pub))
+
+    dts <- e$Date
+    first_rel <- if (length(pub_w)) dts[pub_w[1]] else NA
+    first_arc <- if (length(arc_w)) dts[arc_w[1]] else NA
+    last_rel <- if (length(pub_w)) dts[pub_w[length(pub_w)]] else NA
+    last_arc <- if (length(arc_w)) dts[arc_w[length(arc_w)]] else NA
+
+    pkg_info <- data.frame(
+        First.Release = first_rel,
+        First.Archival = first_arc,
+        Last.Release = last_rel,
+        Last.Archival = last_arc,
+        Published = length(pub_w),
+        Archived = length(arc_w),
+        check.names = FALSE
+    )
+    cbind(pkg_info,
+          before_after(arc_w, pub_w, e)
+    )
+}
+
+before_after <- function(ref, abc, pkg_info) {
+    a <- b <- vector(mode = "numeric", length(ref))
+    # We compare by position (sorted by date & Time!!)
+    # Not possible to have the same position both Archived and Published
+    for (i in seq_along(ref)) {
+        before <- abc[abc < ref[i]]
+        b[i] <- if (length(before)) {
+            max(before)
+        } else {
+            NA
+        }
+        after <- abc[abc > ref[i]]
+        a[i] <- if (length(after)) {
+            min(after)
+        } else {
+            NA
+        }
+    }
+    df <- data.frame(Published.Before = pkg_info$Date[b],
+                     Archived.Date = pkg_info$Date[ref],
+                     Published.After = pkg_info$Date[a],
+                     Archived.by = pkg_info$User[ref],
+                     check.names = FALSE)
+    if (!nrow(df)) {
+        df[1L, , drop = FALSE]
+    } else {
+        df
+    }
+}
+
+pkgs_dates <- lapply(s_pkg, around_archive)
+table(lens <- vapply(pkgs_dates, NROW, 0L))
+
+## Unarchivals:
+udb <- cbind(Package = rep.int(names(pkgs_dates), lens),
+             do.call(rbind, pkgs_dates))
+
+udb$First.Release <- as.Date(udb$First.Release, origin = "1970-01-01")
+udb$Last.Release <- as.Date(udb$Last.Release, origin = "1970-01-01")
+udb_delta <- cbind(udb,
+                   Delta.Before = as.numeric(difftime(udb$Archived.Date, udb$Published.Before, units = "days")),
+                   Delta.After = as.numeric(difftime(udb$Published.After, udb$Archived.Date, units = "days")))
+
+tab_a <- do.call(rbind,
+               with(udb_delta[!is.na(udb_delta$Archived.Date), ],
+                    tapply(Delta.After,
+                           format(Published.Before, "%Y"),
+                           function(e)
+                               c(summary(e), n = length(e))
+                           )))
+tab_p <- do.call(rbind,
+               with(udb_delta[!is.na(udb_delta$Archived.Date), ],
+                    tapply(Delta.Before,
+                           format(Published.Before, "%Y"),
+                           function(e)
+                               c(summary(e), n = length(e))
+                           )))
+
+
+who <- do.call(rbind,
+               with(udb_delta[!is.na(udb_delta$User), ],
+                    tapply(User,
+                           format(Publish, "%Y"),
+                           function(e){c(summary(e), total = length(e))})))
+
+
+total_packages <- function(action_s) {
+    new_p <- unique(udb[, c("Package", "First.Release", "Archived.Date", "Published.After")])
+    rel_dates <- unique(c(new_p$First.Release, new_p$Published.Before, new_p$Archived.Date, new_p$Published.After))
+    rel_dates <- sort(na.omit(rel_dates))
+    dates <- sapply(rel_dates, function(d, new_p) {
+        # arc_d <- new_p$Archived.Date == d
+        new_packages <- sum(new_p$First.Release == d, na.rm = TRUE)
+        archived <- sum(new_p$Archived.Date == d, na.rm = TRUE)
+        resubmitted <- sum(new_p$Published.After == d, na.rm = TRUE)
+        c(new_packages = new_packages,
+          archived = archived,
+          resubmitted = resubmitted,
+          removed =  resubmitted)
+    }, new_p = new_p)
+    da <- as.data.frame(t(dates))
+    da$date <- rel_dates
+    da$total <- da$new_packages - da$archived + da$resubmitted
+    da$ctotal <- cumsum(da$total)
+
+}
+new_pkg <- data.frame(New.Packages = new_p,
+                      Date = unique(actions_s$Date), check.names = FALSE)

--- a/inst/scripts/dependency_evolution.R
+++ b/inst/scripts/dependency_evolution.R
@@ -1,0 +1,132 @@
+library(parallel)
+library(data.table)
+
+# Given a path to a *.tar.gz source package, try to parse its
+# DESCRIPTION. Returns either a 'packageDescription2' object, or (if
+# failed) a named character vector containing the results of read.dcf(),
+# of (if failed) an unnamed character vector containing the contents of
+# DESCRIPTION, or NULL (if there was no such file).
+extract_one <- function(f) {
+	message(basename(f))
+	f <- normalizePath(f)
+	d <- tempfile(paste0('untar', Sys.getpid()))
+
+	stopifnot(dir.create(d))
+	on.exit(unlink(d, TRUE), add = TRUE)
+
+	owd <- setwd(d)
+	on.exit(setwd(owd), add = TRUE)
+
+	file.path(basename(f) |> sub('_.*', '', x = _), 'DESCRIPTION') |>
+		untar(f, files = _) -> ret
+	if (ret) return(NULL)
+
+	file <- Sys.glob('*/DESCRIPTION')
+	if (!length(file)) return(file)
+
+	file |>
+		tools:::.read_description() |>
+		tools:::.split_description() |> try() -> ret
+	if (!inherits(ret, 'try-error')) return(ret)
+
+	file |> read.dcf() |> try() -> ret
+	if (!inherits(ret, 'try-error')) return(ret)
+
+	readLines(file)
+}
+
+# Given a directory containing source packages, apply extract_one() to
+# every *.tar.gz file and return a list with basename() as names.
+# 'cl' can be a 'parallel' cluster object or the number of processes.
+extract_all <- function(d, cl = NULL) {
+	if (is.numeric(cl)) {
+		cl <- makeCluster(cl)
+		on.exit(stopCluster(cl))
+	}
+
+	parLapplyLB(
+		cl,
+		# FIXME: ideally should only look at $d/*.tar.gz and
+		# $d/Archive/*/*.tar.gz
+		list.files(
+			d, pattern = '\\.tar\\.gz$',
+			recursive = TRUE, full.names = TRUE
+		) |> (\(.) setNames(., basename(.)))(),
+		extract_one
+	)
+}
+
+# Given a list returned by extract_all(), produce a data.table of
+# packages and their versions and dependencies.
+to_table <- function(l) {
+	l |> lapply(\(x)
+		# some DESCRIPTIONs fail to parse altogether;
+		# others are for Bundles, not Packages, and so on
+		if (is.list(x) && !is.na(x$DESCRIPTION['Package']))
+			with(x, data.table(
+				Package = DESCRIPTION['Package'],
+				Version = package_version(DESCRIPTION['Version'], strict = FALSE),
+				Depends = list(Depends),
+				Imports = list(Imports),
+				LinkingTo = list(LinkingTo)
+			))
+	) |> rbindlist() -> ret
+	# duplicates are Recommended packages themselves
+	# package_version is a list, so can't use forder()/key/index
+	ret[!duplicated(paste(Package, Version)) & !is.na(Version)][base::order(Package, Version)]
+}
+
+base_or_recommended <- c("R", "base", "tools", "utils", "grDevices",
+"graphics", "stats", "datasets", "methods", "grid", "splines", "stats4",
+"tcltk", "compiler", "parallel", "MASS", "lattice", "Matrix", "nlme",
+"survival", "boot", "cluster", "codetools", "foreign", "KernSmooth",
+"rpart", "class", "nnet", "spatial", "mgcv")
+
+# Which updates lose a strong, non-base-or-Recommended dependency?
+incremental_dependency_loss <- \(x) x[,
+	# combine all strong dependencies together
+	strong :=
+		Map(c, Depends, Imports, LinkingTo) |>
+		lapply(names) |>
+		lapply(setdiff, base_or_recommended)
+][
+	# filter out packages with only one version
+	x[, .(N = .N), by=Package][N > 1],
+	on = 'Package',
+	nomatch = NULL
+][,
+	# find out which strong dependencies were lost on updates
+	.(
+		Package = Package,
+		# otherwise data.table's runlock() spends more time walking these than merging
+		Version.old = as.character(Version)[-.N],
+		Version.new = as.character(Version[-1]),
+		dependency_decrease = Map(setdiff, strong[-.N], strong[-1])
+	),
+	by = Package
+]
+
+# Which package versions don't have strong, non-base-or-Recommended
+# dependencies missing from the latest version?
+cumulative_dependency_loss <- \(x) x[,
+	# combine all strong dependencies together
+	strong :=
+		Map(c, Depends, Imports, LinkingTo) |>
+		lapply(names) |>
+		lapply(setdiff, base_or_recommended)
+][
+	# filter out packages with only one version
+	x[, .(N = .N), by=Package][N > 1],
+	on = 'Package',
+	nomatch = NULL
+][,
+	# find out which strong dependencies were lost on updates
+	.(
+		Package = Package,
+		# otherwise data.table's runlock() spends more time walking these than merging
+		Version.old = as.character(Version)[-.N],
+		Version.new = as.character(Version[-1]),
+		dependency_decrease = Map(setdiff, strong[-.N], MoreArgs = tail(strong,1))
+	),
+	by = Package
+]

--- a/man/cran_alias.Rd
+++ b/man/cran_alias.Rd
@@ -16,7 +16,7 @@ A data.frame with three columns: Package, Source and Target.
 Retrieve alias available on CRAN.
 }
 \examples{
-ca <- cran_alias()
+ca <- cran_alias("BWStest")
 head(ca)
 }
 \seealso{

--- a/man/cran_archive.Rd
+++ b/man/cran_archive.Rd
@@ -26,7 +26,7 @@ a warning regarding a package being both archived and current.
 }
 \examples{
 \donttest{
-ca <- cran_archive()
+ca <- cran_archive("A3")
 head(ca)
 }
 }

--- a/man/cran_archive.Rd
+++ b/man/cran_archive.Rd
@@ -26,7 +26,9 @@ a warning regarding a package being both archived and current.
 }
 \examples{
 \donttest{
-ca <- cran_archive("A3")
+ap <- available.packages()
+a_package <- rownames(ap)[startsWith(rownames(ap), "A")][2]
+ca <- cran_archive(a_package)
 head(ca)
 }
 }

--- a/man/cran_help_cliques.Rd
+++ b/man/cran_help_cliques.Rd
@@ -11,6 +11,7 @@ cran_help_cliques(packages = NULL)
 }
 \value{
 Return a data.frame of help pages not connected to the network of help pages.
+Or NULL if nothing are found.
 }
 \description{
 Some help pages have links to and from but they are closed networks.
@@ -19,7 +20,7 @@ Some help pages have links to and from but they are closed networks.
 Requires igraph
 }
 \examples{
-chc <- cran_help_cliques()
+chc <- cran_help_cliques("DZEXPM")
 head(chc)
 }
 \seealso{

--- a/man/cran_help_pages_not_linked.Rd
+++ b/man/cran_help_pages_not_linked.Rd
@@ -17,7 +17,9 @@ Help pages without links to other help pages.
 This makes harder to navigate to related help pages.
 }
 \examples{
-chnl <- cran_help_pages_not_linked("A3")
+ap <- available.packages()
+a_package <- rownames(ap)[startsWith(rownames(ap), "A")][1]
+chnl <- cran_help_pages_not_linked(a_package)
 head(chnl)
 }
 \seealso{

--- a/man/cran_help_pages_wo_links.Rd
+++ b/man/cran_help_pages_wo_links.Rd
@@ -17,7 +17,9 @@ Help pages without links from other help pages.
 This makes harder to find them.
 }
 \examples{
-chwl <- cran_help_pages_wo_links("A3")
+ap <- available.packages()
+a_package <- rownames(ap)[startsWith(rownames(ap), "a")][1]
+chwl <- cran_help_pages_wo_links(a_package)
 head(chwl)
 }
 \seealso{

--- a/man/cran_links.Rd
+++ b/man/cran_links.Rd
@@ -17,7 +17,7 @@ It has 4 columns: Package, Anchor, Target and Source.
 Retrieve links on CRAN packages' R documentation files.
 }
 \examples{
-cl <- cran_links()
+cl <- cran_links("CytoSimplex")
 head(cl)
 }
 \seealso{

--- a/man/cran_snapshot.Rd
+++ b/man/cran_snapshot.Rd
@@ -17,7 +17,8 @@ Given the available information which packages were on CRAN on a given date?
 }
 \note{
 Due to missing of CRAN comments some packages are not annotated when
-were they archived and more packages will be returned for any given date.
+were they archived and more packages than present might be returned for any
+given date.
 }
 \examples{
 cs <- cran_snapshot(Sys.Date() -2 )

--- a/man/cran_snapshot.Rd
+++ b/man/cran_snapshot.Rd
@@ -20,5 +20,6 @@ Due to missing of CRAN comments some packages are not annotated when
 were they archived and more packages will be returned for any given date.
 }
 \examples{
-cran_snapshot(Sys.Date() -2 )
+cs <- cran_snapshot(Sys.Date() -2 )
+head(cs)
 }

--- a/man/package_dependencies.Rd
+++ b/man/package_dependencies.Rd
@@ -7,7 +7,7 @@
 package_dependencies(pkg = ".", which = "strong")
 }
 \arguments{
-\item{pkg}{Path to a file with a DESCRIPTION file or a the name of a package.}
+\item{pkg}{Path to a file with a DESCRIPTION file or a package's names.}
 
 \item{which}{a character vector listing the types of
     dependencies, a subset of
@@ -20,7 +20,7 @@ package_dependencies(pkg = ".", which = "strong")
   }
 }
 \value{
-A data.frame with the name, version required and version used.
+A data.frame with the name, version required, if only one package is provided it also show the version used.
 }
 \description{
 Despite the description minimal requirements find which versions are

--- a/repo.data.Rproj
+++ b/repo.data.Rproj
@@ -1,0 +1,23 @@
+Version: 1.0
+ProjectId: 1559f8b4-9f88-4bc8-9b2b-076928562884
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 4
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/tests/test1.R
+++ b/tests/test1.R
@@ -1,7 +1,26 @@
 # Raw testing without using any package (testthat or tinytest) as described on WRE
 
 library("repo.data")
+# cran archive ####
 pkges <- c("BaseSet", "dplyr")
 cpk <- cran_archive(pkges)
 pkgs_out <- setdiff(pkges, cpk$package)
 length(pkgs_out) == 0
+cpk2 <- cran_archive(pkges)
+identical(cpk, cpk2)
+
+# cran alias ####
+pkges <- c("BaseSet", "dplyr")
+cpk <- cran_alias(pkges)
+pkgs_out <- setdiff(pkges, cpk$package)
+length(pkgs_out) == 0
+cpk2 <- cran_alias(pkges)
+identical(cpk, cpk2)
+
+# cran links ####
+pkges <- c("BaseSet", "dplyr")
+cpk <- cran_links(pkges)
+pkgs_out <- setdiff(pkges, cpk$package)
+length(pkgs_out) == 0
+cpk2 <- cran_links(pkges)
+identical(cpk, cpk2)

--- a/tests/test1.R
+++ b/tests/test1.R
@@ -1,6 +1,7 @@
 # Raw testing without using any package (testthat or tinytest) as described on WRE
 
 library("repo.data")
+options(repos = "https://CRAN.R-project.org")
 # cran archive ####
 pkges <- c("BaseSet", "dplyr")
 cpk <- cran_archive(pkges)

--- a/tests/test1.R
+++ b/tests/test1.R
@@ -3,34 +3,51 @@
 library("repo.data")
 options(repos = "https://CRAN.R-project.org")
 # cran archive ####
+rtweet <- cran_archive("rtweet")
+stopifnot(nrow(rtweet) >= 15L)
+# Repeat search for a different package to test for accessing the cache with a package currently on CRAN
+BaseSet <- cran_archive("BaseSet")
+stopifnot(nrow(BaseSet) > 1L && nrow(BaseSet) < 200)
+# Test on a package without archive
+ABACUS <- cran_archive("ABACUS")
+stopifnot(nrow(ABACUS) == 1L)
+
 pkges <- c("BaseSet", "dplyr")
 cpk <- cran_archive(pkges)
 pkgs_out <- setdiff(pkges, cpk$package)
-length(pkgs_out) == 0
+stopifnot(identical(pkgs_out, pkges))
 cpk2 <- cran_archive(pkges)
-identical(cpk, cpk2)
+stopifnot(identical(cpk, cpk2))
 
 # cran alias ####
 pkges <- c("BaseSet", "dplyr")
 cpk <- cran_alias(pkges)
 pkgs_out <- setdiff(pkges, cpk$package)
-length(pkgs_out) == 0
+stopifnot(identical(pkgs_out, pkges))
 cpk2 <- cran_alias(pkges)
-identical(cpk, cpk2)
+stopifnot(identical(cpk, cpk2))
 
 # cran links ####
 pkges <- c("BaseSet", "dplyr")
 cpk <- cran_links(pkges)
 pkgs_out <- setdiff(pkges, cpk$package)
-length(pkgs_out) == 0
+stopifnot(identical(pkgs_out, pkges))
 cpk2 <- cran_links(pkges)
-identical(cpk, cpk2)
+stopifnot(identical(cpk, cpk2))
 
 
 # dependencies ####
 pkges <- c("BaseSet")
-cpk <- package_dependencies(pkges)
+suppressWarnings(cpk <- package_dependencies(pkges))
+stopifnot(ncol(cpk) == 6L)
 pkgs_out <- setdiff(pkges, cpk$package)
-length(pkgs_out) == 0
-cpk2 <- package_dependencies(pkges)
-identical(cpk, cpk2)
+stopifnot(identical(pkgs_out, pkges))
+suppressWarnings(cpk2 <- package_dependencies(pkges))
+stopifnot(identical(cpk, cpk2))
+
+suppressWarnings(pd <- package_dependencies(c("ggeasy", "BaseSet")))
+stopifnot(ncol(pd) == 2L)
+
+# Snapshot ####
+cs <- cran_snapshot(Sys.Date() -2 )
+stopifnot(NROW(cs) > 1000)

--- a/tests/test1.R
+++ b/tests/test1.R
@@ -24,3 +24,12 @@ pkgs_out <- setdiff(pkges, cpk$package)
 length(pkgs_out) == 0
 cpk2 <- cran_links(pkges)
 identical(cpk, cpk2)
+
+
+# dependencies ####
+pkges <- c("BaseSet")
+cpk <- package_dependencies(pkges)
+pkgs_out <- setdiff(pkges, cpk$package)
+length(pkgs_out) == 0
+cpk2 <- package_dependencies(pkges)
+identical(cpk, cpk2)

--- a/vignettes/repo.data.Rmd
+++ b/vignettes/repo.data.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
+setRepositories(ind = 1, graphics = FALSE)
 library(repo.data)
 ```
 

--- a/vignettes/repo.data.Rmd
+++ b/vignettes/repo.data.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-options(repos = "https://CRAN.R-project.org")
+options(repos = c("@CRAN@" = "https://CRAN.R-project.org"))
 library(repo.data)
 ```
 

--- a/vignettes/repo.data.Rmd
+++ b/vignettes/repo.data.Rmd
@@ -65,7 +65,7 @@ If you ever wonder which packages are at risk you can use `cran_doom()`:
 ```{r doom}
 cd <- cran_doom(bioc = TRUE)
 cd[c("time_till_last", "last_archived", "npackages")]
-knitr::kable(cd$details)
+knitr::kable(head(cd$details))
 ```
 
 

--- a/vignettes/repo.data.Rmd
+++ b/vignettes/repo.data.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-setRepositories(ind = 1, graphics = FALSE)
+options(repos = "https://CRAN.R-project.org")
 library(repo.data)
 ```
 


### PR DESCRIPTION
Modified `cran_links()` and `cran_alias()` for faster processing when only requesting a few packages (while keeping the fast cache if all are requested).

TODO:
 - [x] Anything to do with tools::CRAN_archive_db()
 - [x] Check implications from `cran_alias()`
 - [x] Check implications from `cran_links()`